### PR TITLE
Bumping curl & python3.12 versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,9 +33,9 @@ apt-get update --yes
 
 apt-get install --no-install-recommends --yes \
   "ca-certificates=20240203" \
-  "curl=8.5.0-2ubuntu10.4" \
+  "curl=8.5.0-2ubuntu10.5" \
   "libpq-dev=16.4-0ubuntu0.24.04.2" \
-  "python3.12=3.12.3-1ubuntu0.2" \
+  "python3.12=3.12.3-1ubuntu0.3" \
   "python3-pip=24.0+dfsg-1ubuntu1"
 
 apt-get clean --yes


### PR DESCRIPTION
https://github.com/ministryofjustice/data-platform-support/issues/979

It's failing to build due to missing `curl` and `python312` versions. I know this isn't a full patch. Will pick the rest up a bit later.