### PR TITLE
🚚 Add migration command if database is Postgres

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -3,8 +3,8 @@ apiVersion: v2
 name: mlflow
 description: MLflow Tracking Server
 type: application
-version: 2.21.3-rc5
-appVersion: 2.21.3-rc5
+version: 2.21.3-rc6
+appVersion: 2.21.3-rc6
 home: https://github.com/ministryofjustice/analytical-platform-mlflow
 sources:
   - https://github.com/mlflow/mlflow

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -6,7 +6,7 @@ fullnameOverride: ""
 image:
   repository: ghcr.io/ministryofjustice/analytical-platform-mlflow
   pullPolicy: IfNotPresent
-  tag: 2.21.3-rc5
+  tag: 2.21.3-rc6
 
 imagePullSecrets: []
 

--- a/src/usr/local/bin/entrypoint.sh
+++ b/src/usr/local/bin/entrypoint.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 export MLFLOW_AUTH_CONFIG_PATH="${MLFLOW_ROOT}/auth.ini"
 export MLFLOW_AUTH_ADMIN_USERNAME="${MLFLOW_AUTH_ADMIN_USERNAME:-"analyticalplatform"}"
 export MLFLOW_AUTH_ADMIN_PASSWORD="${MLFLOW_AUTH_ADMIN_PASSWORD:-"analyticalplatform"}"
@@ -12,17 +14,25 @@ export MLFLOW_SERVER_WORKERS="${MLFLOW_SERVER_WORKERS:-"1"}"
 export MLFLOW_SERVER_BACKEND_STORE_URI="${MLFLOW_SERVER_BACKEND_STORE_URI:-"sqlite:///mlflow.db"}"
 export MLFLOW_SERVER_DEFAULT_ARTIFACT_ROOT="${MLFLOW_SERVER_DEFAULT_ARTIFACT_ROOT:-"${MLFLOW_ROOT}/mlruns"}"
 
+echo "Configuring ${MLFLOW_AUTH_CONFIG_PATH}"
 sed --in-place "s|ADMIN_USERNAME|${MLFLOW_AUTH_ADMIN_USERNAME}|" "${MLFLOW_AUTH_CONFIG_PATH}"
 sed --in-place "s|ADMIN_PASSWORD|${MLFLOW_AUTH_ADMIN_PASSWORD}|" "${MLFLOW_AUTH_CONFIG_PATH}"
 sed --in-place "s|DATABASE_URI|${MLFLOW_AUTH_DATABASE_URI}|" "${MLFLOW_AUTH_CONFIG_PATH}"
 sed --in-place "s|DEFAULT_PERMISSION|${MLFLOW_AUTH_DEFAULT_PERMISSION}|" "${MLFLOW_AUTH_CONFIG_PATH}"
 
 if [[ "${MLFLOW_SERVER_DEV_MODE}" == "true" ]]; then
+  echo "Running in development mode"
   MLFLOW_SERVER_DEV_MODE_FLAG="--dev"
 else
   MLFLOW_SERVER_DEV_MODE_FLAG=""
 fi
 
+if [[ "${MLFLOW_SERVER_BACKEND_STORE_URI}" == "postgresql://"* ]]; then
+  echo "Running database migrations"
+  mlflow db upgrade "${MLFLOW_SERVER_BACKEND_STORE_URI}"
+fi
+
+echo "Starting MLflow server"
 mlflow server ${MLFLOW_SERVER_DEV_MODE_FLAG} \
   --host "${MLFLOW_SERVER_HOST}" \
   --port "${MLFLOW_SERVER_PORT}" \


### PR DESCRIPTION
## Proposed Changes

- Adds logic to perform database migration if backend is Postgres
  - During deployment of [2.21.3-rc5](https://github.com/ministryofjustice/analytical-platform-mlflow/releases/tag/2.21.3-rc5) via https://github.com/ministryofjustice/modernisation-platform-environments/pull/10212 it failed as the schema was out of date (`ERROR mlflow.cli: Detected out-of-date database schema (found version 4465047574b1, but expected 0584bdc529eb)`). I had to edit the deployment (removing liveness and readiness probes, and sleeping infinity), exec in and run `mlflow db upgrade "${MLFLOW_SERVER_BACKEND_STORE_URI}"` to fix
- Prepares `2.21.3-rc6` release
- Adds comments useful for debugging startup

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>