### PR TITLE
Maintenance - update libpq-dev and python3.12 versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,8 @@ apt-get update --yes
 apt-get install --no-install-recommends --yes \
   "ca-certificates=20240203" \
   "curl=8.5.0-2ubuntu10.6" \
-  "libpq-dev=16.8-0ubuntu0.24.04.1" \
-  "python3.12=3.12.3-1ubuntu0.5" \
+  "libpq-dev=16.9-0ubuntu0.24.04.1" \
+  "python3.12=3.12.3-1ubuntu0.6" \
   "python3-pip=24.0+dfsg-1ubuntu1.1"
 
 apt-get clean --yes

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/ubuntu/ubuntu:24.04@sha256:4d860156ddae5923ed93d6b161c6b2f0f437d8086210f087db85b83fc2689914
+FROM public.ecr.aws/ubuntu/ubuntu:24.04@sha256:932333528e27f2be8ae92535c4c3c2c1030a4cf368abbec1cf61d9ee8aa7cf41
 
 LABEL org.opencontainers.image.vendor="Ministry of Justice" \
       org.opencontainers.image.authors="Analytical Platform (analytical-platform@digital.justice.gov.uk)" \

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -3,8 +3,8 @@ apiVersion: v2
 name: mlflow
 description: MLflow Tracking Server
 type: application
-version: 2.21.3-rc7
-appVersion: 2.21.3-rc7
+version: 2.21.3-rc8
+appVersion: 2.21.3-rc8
 home: https://github.com/ministryofjustice/analytical-platform-mlflow
 sources:
   - https://github.com/mlflow/mlflow

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -6,7 +6,7 @@ fullnameOverride: ""
 image:
   repository: ghcr.io/ministryofjustice/analytical-platform-mlflow
   pullPolicy: IfNotPresent
-  tag: 2.21.3-rc7
+  tag: 2.21.3-rc9
 
 imagePullSecrets: []
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -6,7 +6,7 @@ fullnameOverride: ""
 image:
   repository: ghcr.io/ministryofjustice/analytical-platform-mlflow
   pullPolicy: IfNotPresent
-  tag: 2.21.3-rc9
+  tag: 2.21.3-rc8
 
 imagePullSecrets: []
 

--- a/src/opt/mlflow/requirements.txt
+++ b/src/opt/mlflow/requirements.txt
@@ -1,5 +1,5 @@
 boto3==1.37.29
-mlflow==2.21.3
-mlflow[auth]==2.21.3
+mlflow==2.22.1
+mlflow[auth]==2.22.1
 psycopg2-binary==2.9.10
 h11==0.16.0

--- a/test/container-structure-test.yml
+++ b/test/container-structure-test.yml
@@ -37,7 +37,7 @@ commandTests:
   - name: "mlflow"
     command: "mlflow"
     args: ["--version"]
-    expectedOutput: ["mlflow, version 2.21.3"]
+    expectedOutput: ["mlflow, version 2.22.1"]
 
 fileExistenceTests:
   - name: "/opt/mlflow"


### PR DESCRIPTION
The scheduled container [scan](https://github.com/ministryofjustice/analytical-platform-mlflow/actions/runs/15728700384/job/44324491913#step:6:371) flagged CVE-2025-4565 relating to the `protobuf` Python library.

`protobuf` is installed as a dependency of`mlflow `

The following packages required updates
- ubuntu:24.04
- mlflow
- libpq-dev 
- python3.12 

As part of the rebuild process, mlflow and its dependencies were reinstalled, which pulled in the fixed version of protobuf (≥ 5.29.5), resolving the vulnerability.

The container has been rescanned and confirmed clean of this CVE.
