### PR TITLE
:dependabot: Group MLflow dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,3 +30,7 @@ updates:
     commit-message:
       prefix: ":dependabot: pip"
       include: "scope"
+    groups:
+      mlflow:
+        patterns:
+          - "mlflow*"


### PR DESCRIPTION
## Proposed Changes

- MLflow packages need to be group otherwise they get upset 

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>