### PR TITLE
CVE alert fix - libc updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,10 @@ useradd \
 
 apt-get update --yes
 
+apt-get install --no-install-recommends --yes --only-upgrade \
+  "libc-bin=2.39-0ubuntu8.8" \
+  "libc6=2.39-0ubuntu8.8"
+
 apt-get install --no-install-recommends --yes \
   "ca-certificates=20260601~24.04.1" \
   "curl=8.5.0-2ubuntu10.11" \


### PR DESCRIPTION
This pull request makes a targeted update to the `Dockerfile` to address system library versions. The main change is upgrading the `libc-bin` and `libc6` packages to a specific version before installing other dependencies. This can help ensure compatibility and security in the Docker image.

Dependency updates:

* Upgraded `libc-bin` and `libc6` to version `2.39-0ubuntu8.8` using `apt-get install --only-upgrade` before installing other packages.

### Why This Fix Works

1. **Explicit Upgrade**: The `--only-upgrade` flag ensures only already-installed packages are upgraded, preventing unexpected behavior
2. **Pinned Versions**: Specifying version `2.39-0ubuntu8.8` ensures reproducibility and prevents future version mismatches
3. **Dependency Order**: Upgrading libc packages before other applications depend on them prevents compatibility issues
4. **Base Image Agnostic**: Works regardless of whether the base image contains an older or newer version